### PR TITLE
Fix: Configure Vite build output directory to 'dist'

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   },
 root: path.resolve(path.dirname(new URL(import.meta.url).pathname), "client"),
   build: {
-  outDir: path.resolve(path.dirname(new URL(import.meta.url).pathname), "dist/public"),
+  outDir: path.resolve(path.dirname(new URL(import.meta.url).pathname), "dist"),
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
The Vite build configuration (`vite.config.ts`) was previously set to output build artifacts to `dist/public`. However, various deployment configurations (GitHub Pages, Vercel, Netlify, Docker, and manual scripts) expect the build output to be directly in the `dist` directory.

This change modifies `vite.config.ts` to set `build.outDir` to `dist`. This ensures that `index.html` and other static assets are placed in the correct location, resolving an issue where deployments might serve a directory listing instead of the application.

The GitHub Actions workflow (`.github/workflows/deploy.yml`) and instructions in `DEPLOYMENT.md` have been reviewed and confirm that `dist` is the expected output path.