### PR TITLE
I've made some changes to correct the SPA routing for the production …

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts > dev_audit.log 2>&1",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && cp dist/index.html dist/404.html",
     "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -69,7 +69,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(path.dirname(new URL(import.meta.url).pathname), "public");
+  const distPath = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "dist");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(


### PR DESCRIPTION
…server and enhance GitHub Pages compatibility.

- I modified `server/vite.ts` to ensure the `serveStatic` function correctly points to the project root `dist` directory instead of `server/public`. This allows the Express server to find and serve `index.html` and other static assets for client-side routes when running in production mode (`npm run start`).

- I updated the `build` script in `package.json` to copy `dist/index.html` to `dist/404.html`. This is a common workaround for single-page applications hosted on static platforms like GitHub Pages, ensuring that requests to client-side routes are directed to the main `index.html` file, allowing the client-side router to manage the navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build process to copy the main HTML file to a 404 page after building.
  - Changed the static files directory for the server from "public" to "dist".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->