### PR TITLE
Temporary stub for AuthContext

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,67 +1,17 @@
-import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
-import { User, onAuthStateChanged, signOut as firebaseSignOut, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
-import { auth } from '../firebaseConfig'; // Adjust path if necessary
+import React, { ReactNode } from 'react';
+// import { User, onAuthStateChanged, signOut as firebaseSignOut, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+// import { auth } from '../firebaseConfig'; // Adjust path if necessary
 
-interface AuthContextType {
-  currentUser: User | null;
-  loading: boolean;
-  signInWithGoogle: () => Promise<void>;
-  signOut: () => Promise<void>;
-}
-
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+// export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = null; // Temporary placeholder
 
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [currentUser, setCurrentUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  const signInWithGoogle = async () => {
-    const provider = new GoogleAuthProvider();
-    try {
-      await signInWithPopup(auth, provider);
-      // onAuthStateChanged will handle setting the currentUser
-    } catch (error) {
-      console.error("Error during Google sign-in:", error);
-      // Optionally, re-throw or handle specific errors
-      throw error;
-    }
-  };
-
-  const signOut = async () => {
-    try {
-      await firebaseSignOut(auth);
-      // onAuthStateChanged will handle setting the currentUser to null
-    } catch (error) {
-      console.error("Error during sign-out:", error);
-      // Optionally, re-throw or handle specific errors
-      throw error;
-    }
-  };
-
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setCurrentUser(user);
-      setLoading(false);
-    });
-
-    // Cleanup subscription on unmount
-    return () => unsubscribe();
-  }, []);
-
-  const value = {
-    currentUser,
-    loading,
-    signInWithGoogle,
-    signOut,
-  };
-
-  return <AuthContext.Provider value={value}>{!loading && children}</AuthContext.Provider>;
+  return <>{children}</>;
 };
 
-export const useAuth = (): AuthContextType => {
-  const context = useContext(AuthContext);
-  if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
-  }
-  return context;
-};
+export const useAuth = () => ({
+  currentUser: null,
+  loading: false,
+  signInWithGoogle: async () => {},
+  signOut: async () => {},
+});


### PR DESCRIPTION
## Summary
- comment out Firebase imports in `AuthContext.tsx`
- export placeholder context and stub hooks to bypass Firebase

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847793ab64c8322b2bf7d476392f569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Authentication features have been disabled. User authentication is no longer available, and related sign-in and sign-out actions are now non-functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->