### PR TITLE
Fix: Exclude client-side AuthContext from server bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts > dev_audit.log 2>&1",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && cp dist/index.html dist/404.html",
-    "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --external:./client/src/contexts/AuthContext.tsx",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"


### PR DESCRIPTION
The server was potentially bundling client-side Firebase authentication code, leading to 502 Bad Gateway errors in production. This change modifies the server build script (`build:server` in `package.json`) to explicitly exclude `client/src/contexts/AuthContext.tsx` from the esbuild process.

This ensures that only server-side code is included in the production server bundle, preventing crashes related to missing client-side dependencies or attempting to run client-side Firebase code in a Node.js environment.