### PR TITLE
Fix: Implement Firebase login and correct sign-in flow

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,17 +1,57 @@
-import React, { ReactNode } from 'react';
-// import { User, onAuthStateChanged, signOut as firebaseSignOut, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
-// import { auth } from '../firebaseConfig'; // Adjust path if necessary
+import React, { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+import { User, onAuthStateChanged, signOut as firebaseSignOut, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+import { auth } from '../firebaseConfig'; // Adjust path if necessary
 
-// export const AuthContext = createContext<AuthContextType | undefined>(undefined);
-export const AuthContext = null; // Temporary placeholder
+interface AuthContextType {
+  currentUser: User | null;
+  loading: boolean;
+  signInWithGoogle: () => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  return <>{children}</>;
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setCurrentUser(user);
+      setLoading(false);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const signInWithGoogle = async () => {
+    try {
+      await signInWithPopup(auth, new GoogleAuthProvider());
+    } catch (error) {
+      console.error("Error signing in with Google:", error);
+      // Handle error appropriately in a real app (e.g., show a toast notification)
+    }
+  };
+
+  const signOut = async () => {
+    try {
+      await firebaseSignOut(auth);
+    } catch (error) {
+      console.error("Error signing out:", error);
+      // Handle error appropriately
+    }
+  };
+
+  return (
+    <AuthContext.Provider value={{ currentUser, loading, signInWithGoogle, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
 };
 
-export const useAuth = () => ({
-  currentUser: null,
-  loading: false,
-  signInWithGoogle: async () => {},
-  signOut: async () => {},
-});
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -1,9 +1,11 @@
 import { Button } from "@/components/ui/button";
 import { FileText, Users, Github, Share2, Download } from "lucide-react";
 import { useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function Landing() {
   const [, setLocation] = useLocation();
+  const { signInWithGoogle } = useAuth();
 
   const handleGetStarted = () => {
     setLocation("/editor");
@@ -26,7 +28,7 @@ export default function Landing() {
             </div>
             <Button 
               variant="outline" 
-              onClick={handleGetStarted}
+              onClick={signInWithGoogle}
               className="border-border text-foreground hover:bg-muted"
             >
               Sign In


### PR DESCRIPTION
The login functionality was not working because the AuthContext was stubbed out and the 'Sign In' button was incorrectly navigating instead of initiating authentication.

This commit addresses the issue by:
1. Restoring the Firebase authentication logic in `AuthContext.tsx`. This includes:
    - Re-enabling Firebase imports.
    - Implementing `AuthProvider` with state management for `currentUser` and `loading`.
    - Providing `signInWithGoogle` and `signOut` functions that interact with Firebase auth.
    - Subscribing to `onAuthStateChanged` to keep `currentUser` updated.
2. Modifying the 'Sign In' button in `Landing.tsx` to call the `signInWithGoogle` function from `AuthContext` instead of navigating directly to '/editor'.
3. Verifying that `firebaseConfig.ts` is structurally sound for loading Firebase configuration from environment variables.

With these changes, clicking the 'Sign In' button will now trigger the Google authentication flow. If successful, the `AuthContext` will update, and the router logic in `App.tsx` will correctly redirect you to the '/editor' (Home) page.