### PR TITLE
feat: Redirect logged-in users to editor

### DIFF
--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { FileText, Users, Github, Share2, Download } from "lucide-react";
 import { useLocation } from "wouter";
@@ -5,7 +6,13 @@ import { useAuth } from "@/contexts/AuthContext";
 
 export default function Landing() {
   const [, setLocation] = useLocation();
-  const { signInWithGoogle } = useAuth();
+  const { signInWithGoogle, currentUser, loading } = useAuth();
+
+  useEffect(() => {
+    if (!loading && currentUser) {
+      setLocation("/editor", { replace: true });
+    }
+  }, [currentUser, loading, setLocation]);
 
   const handleGetStarted = () => {
     setLocation("/editor");


### PR DESCRIPTION
This commit modifies the Landing page component (`client/src/pages/Landing.tsx`) to automatically redirect you, if you are already logged in, to the `/editor` page.

A `useEffect` hook was added that checks the authentication status (`currentUser` and `loading` from `useAuth`). If you are found to be logged in and the authentication state is not loading, you are redirected to `/editor` using `setLocation("/editor", { replace: true })`. This ensures that you are taken directly to the application's main interface if you are logged in, improving the user experience.

The issue addressed is that previously, if you were logged-in and visited the root URL, you would remain on the Landing page instead of being redirected to the editor.