### PR TITLE
Fix: Prevent COOP error by closing dialogs before redirect

### DIFF
--- a/client/src/components/DocumentSidebar.tsx
+++ b/client/src/components/DocumentSidebar.tsx
@@ -68,6 +68,7 @@ export default function DocumentSidebar({ isOpen, onClose }: DocumentSidebarProp
     },
     onError: (error) => {
       if (isUnauthorizedError(error)) {
+        setCreateDocumentOpen(false);
         toast({
           title: "Unauthorized",
           description: "You are logged out. Logging in again...",
@@ -101,6 +102,7 @@ export default function DocumentSidebar({ isOpen, onClose }: DocumentSidebarProp
     },
     onError: (error) => {
       if (isUnauthorizedError(error)) {
+        setCreateFolderOpen(false);
         toast({
           title: "Unauthorized",
           description: "You are logged out. Logging in again...",


### PR DESCRIPTION
When creating a new document or folder, if an unauthorized error occurred, the application would attempt to redirect to the login page while a dialog was still potentially open or in the process of closing. This could lead to a Cross-Origin-Opener-Policy (COOP) error, as the dialog's cleanup logic (possibly involving a window.close call internally) conflicted with the COOP policy after the browser's security context changed due to the navigation.

This commit modifies the onError handlers in DocumentSidebar.tsx for document and folder creation. It ensures that the respective dialog's state is updated to closed *before* scheduling the redirect to the login page. This should prevent the COOP error by ensuring that any dialog cleanup operations occur within the original security context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Creation dialogs for documents and folders now close automatically if an unauthorized error occurs during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->