### PR TITLE
Fix: Prevent SPA catch-all from serving HTML for API requests

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -43,6 +43,9 @@ export async function setupVite(app: Express, server: Server) {
 
   app.use(vite.middlewares);
   app.use("*", async (req, res, next) => {
+    if (req.originalUrl.startsWith('/api/')) {
+      return next();
+    }
     const url = req.originalUrl;
 
     try {
@@ -80,7 +83,10 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", (req, res, next) => {
+    if (req.originalUrl.startsWith('/api/')) {
+      return next();
+    }
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
I modified the catch-all middleware in both the Vite development server setup (`setupVite`) and the production static server setup (`serveStatic`) within `server/vite.ts`.

These changes ensure that requests with paths starting with `/api/` are not handled by the SPA's HTML-serving catch-all. Instead, if no specific API route matches such a request, the request will be passed to the next error handling middleware, typically resulting in a 404 Not Found response.

This resolves an issue where POST requests to `/api/documents` (and potentially other unhandled API routes) were incorrectly returning the application's HTML page instead of a JSON response or an appropriate API error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request handling to ensure API routes are no longer intercepted by static file middleware, allowing API requests to be processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->