### PR TITLE
Fix: Correct API route order and specificity

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -46,7 +46,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use('/api', authRoutes);
+app.use('/api/auth', authRoutes);
 
 (async () => {
   const server = await registerRoutes(app);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -124,8 +124,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Auth routes
   // IMPORTANT: The root '/' handler above must be registered before any static file serving for '/' or catch-all for SPA.
-  app.get('/api/auth/user', devAuth, async (req: any, res: Response) => {
-    console.log('[/api/auth/user] Handler invoked. req.user:', JSON.stringify(req.user, null, 2));
+  app.get('/user', devAuth, async (req: any, res: Response) => {
+    console.log('[/user] Handler invoked. req.user:', JSON.stringify(req.user, null, 2));
     try {
       if (process.env.NODE_ENV === 'development') {
         const user = await createDevUser();


### PR DESCRIPTION
Previously, authRoutes were mounted at /api before other API routes, causing /api/documents requests to be incorrectly intercepted.

This commit addresses the issue by:
1. Changing the authRoutes prefix from /api to /api/auth in server/index.ts.
2. Updating the user authentication route in server/routes.ts from /api/auth/user to /user, making it relative to the new /api/auth prefix.

This ensures that document API calls are correctly routed to their handlers and auth calls are routed to auth handlers under the more specific /api/auth path.