### PR TITLE
feat: Add About MarkdownMate modal

### DIFF
--- a/client/src/components/AboutModal.tsx
+++ b/client/src/components/AboutModal.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogTrigger, DialogFooter, DialogClose } from '@/components/ui/dialog';
+import { X } from 'lucide-react';
+
+interface AboutModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  const currentYear = new Date().getFullYear();
+  const releaseDate = new Date().toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[600px] bg-card text-card-foreground">
+        <DialogHeader>
+          <DialogTitle className="text-2xl font-semibold">About MarkdownMate</DialogTitle>
+          <DialogClose asChild>
+            <Button variant="ghost" size="icon" className="absolute top-4 right-4">
+              <X className="h-5 w-5" />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogClose>
+        </DialogHeader>
+        <div className="py-4 space-y-6 text-sm">
+          <DialogDescription className="text-center text-muted-foreground">
+            A collaborative real-time markdown editor
+          </DialogDescription>
+
+          <div className="text-center text-xs text-muted-foreground space-y-1">
+            <p>MarkdownMate v1.0.0</p>
+            <p>Released {releaseDate}</p>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium mb-2 text-foreground">Overview</h3>
+            <p className="text-muted-foreground">
+              MarkdownMate is a powerful collaborative markdown editor that enables real-time editing with live preview, syntax highlighting, and seamless team collaboration features.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium mb-2 text-foreground">Key Features</h3>
+            <ul className="list-disc list-inside space-y-1 text-muted-foreground">
+              <li>Real-time collaborative editing with live cursors</li>
+              <li>GitHub Flavored Markdown support with math rendering</li>
+              <li>Monaco Editor (VSCode's editor) integration</li>
+              <li>Live preview with syntax highlighting</li>
+              <li>WebSocket-powered instant synchronization</li>
+              <li>Presence indicators and conflict resolution</li>
+              <li>Light/dark theme support</li>
+              <li>GitHub Pages and Vercel deployment ready</li>
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium mb-2 text-foreground">Tech Stack</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2 text-muted-foreground">
+              <div>
+                <h4 className="font-semibold text-foreground">Frontend:</h4>
+                <p>React 18 · TypeScript · Vite · Tailwind CSS · shadcn/ui</p>
+              </div>
+              <div>
+                <h4 className="font-semibold text-foreground">Editor:</h4>
+                <p>Monaco Editor · GitHub Flavored Markdown · Syntax Highlighting</p>
+              </div>
+              <div>
+                <h4 className="font-semibold text-foreground">Real-time:</h4>
+                <p>WebSocket Integration · Live Cursors · Presence Indicators</p>
+              </div>
+              <div>
+                <h4 className="font-semibold text-foreground">Deployment:</h4>
+                <p>Vite Bundler · GitHub Pages · Vercel Compatible</p>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium mb-2 text-foreground">Prerequisites</h3>
+            <p className="text-muted-foreground">
+              Node.js 18.0.0+ · npm 8.0.0+ (or yarn 1.22.0+)
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium mb-2 text-foreground">Contact</h3>
+            <ul className="space-y-1 text-muted-foreground">
+              <li>Author: 0xWulf</li>
+              <li>Email: <a href="mailto:dev@0xwulf.dev" className="text-primary hover:underline">dev@0xwulf.dev</a></li>
+              <li>GitHub Repo: <a href="https://github.com/hexawulf/MarkdownMate" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">https://github.com/hexawulf/MarkdownMate</a></li>
+            </ul>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AboutModal;

--- a/client/src/components/EditorLayout.tsx
+++ b/client/src/components/EditorLayout.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext"; // Changed import
 import { useTheme } from "@/components/ThemeProvider";
+import { Info } from "lucide-react";
+import AboutModal from "@/components/AboutModal";
 import { useLocation } from "wouter";
 import { useToast } from "@/hooks/use-toast"; // Import useToast
 import { Button } from "@/components/ui/button";
@@ -34,6 +36,10 @@ export default function EditorLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [viewMode, setViewMode] = useState<ViewMode>("split");
   const [collaborationPanelOpen, setCollaborationPanelOpen] = useState(false);
+  const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
+
+  const openAboutModal = () => setIsAboutModalOpen(true);
+  const closeAboutModal = () => setIsAboutModalOpen(false);
 
   const { 
     currentDocument, 
@@ -180,6 +186,15 @@ export default function EditorLayout() {
             </TooltipTrigger>
             <TooltipContent>Toggle Theme</TooltipContent>
           </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="ghost" size="icon" onClick={openAboutModal}>
+                <Info className="w-5 h-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>About MarkdownMate</TooltipContent>
+          </Tooltip>
           
           {/* User Auth Section */}
           <div className="flex items-center space-x-3">
@@ -296,6 +311,8 @@ export default function EditorLayout() {
         onClose={() => setCollaborationPanelOpen(false)}
         documentId={documentId}
       />
+
+      <AboutModal isOpen={isAboutModalOpen} onClose={closeAboutModal} />
     </div>
   );
 }


### PR DESCRIPTION
I've implemented an 'About' modal component accessible via an info icon in the main navigation header.

Key changes:
- I created `client/src/components/AboutModal.tsx` with detailed information about the application, including version, features, tech stack, and contact details.
- I used `shadcn/ui` Dialog component for the modal structure, ensuring responsiveness and accessibility (including ARIA labels, focus trapping, and keyboard navigation).
- I added an info icon button (from `lucide-react`) with a tooltip to `client/src/components/EditorLayout.tsx` in the header, next to the theme toggle.
- I implemented state management in `EditorLayout.tsx` to control the modal's visibility.
- The modal can be closed via the 'X' button, a 'Close' button in the footer, the ESC key, or by clicking on the backdrop.

The new modal provides you with essential information about MarkdownMate, enhancing your experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an "About MarkdownMate" modal accessible from the editor toolbar, providing detailed information about the app, its features, technology stack, prerequisites, and contact details.
  - Added an info icon button in the header to open the About modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->