### PR TITLE
Remove collaboration button from navigation bar

### DIFF
--- a/client/src/components/EditorLayout.tsx
+++ b/client/src/components/EditorLayout.tsx
@@ -151,15 +151,6 @@ export default function EditorLayout() {
         </div>
         
         <div className="flex items-center space-x-3">
-          {/* Collaboration indicators */}
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setCollaborationPanelOpen(!collaborationPanelOpen)}
-          >
-            <Users className="w-5 h-5" />
-          </Button>
-          
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant="ghost" size="icon">


### PR DESCRIPTION
Removes the unused collaboration button (users icon) from the top navigation bar in EditorLayout.tsx to simplify the UI.

The button element with the lucide-users SVG icon and its onClick handler for the collaboration panel have been removed. The CollaborationPanel component and its state remain, but are no longer accessible via this button.