### PR TITLE
Fix: Prevent auto-save race condition during new document import

### DIFF
--- a/client/src/components/EditorLayout.tsx
+++ b/client/src/components/EditorLayout.tsx
@@ -55,7 +55,8 @@ export default function EditorLayout() {
     setContent,
     autoSaveStatus,
     wordCount,
-    charCount 
+    charCount,
+    setIsCreatingNewDocument // Added action
   } = useEditorStore();
 
   // Extract document ID from URL
@@ -83,6 +84,7 @@ export default function EditorLayout() {
         description: `Document "${newDocument.title}" created and imported successfully.`,
         variant: "default",
       });
+      setIsCreatingNewDocument(false); // Reset flag
     },
     onError: (error) => {
       console.error("Error creating document:", error);
@@ -91,6 +93,7 @@ export default function EditorLayout() {
         description: "Could not create a new document. Please try again.",
         variant: "destructive",
       });
+      setIsCreatingNewDocument(false); // Reset flag
     },
   });
 
@@ -105,6 +108,7 @@ export default function EditorLayout() {
         ? importSource.filename.replace(/\.[^/.]+$/, "") // Remove file extension
         : "Imported Document";
       
+      setIsCreatingNewDocument(true); // Set flag before mutation
       // Create new document with imported content
       createDocumentMutation.mutate({
         title,

--- a/client/src/components/MonacoEditor.tsx
+++ b/client/src/components/MonacoEditor.tsx
@@ -64,10 +64,20 @@ export default function MonacoEditor({ documentId }: MonacoEditorProps) {
 
   // Debounced auto-save function
   const debouncedAutoSave = useRef(
-    debounce((content: string) => {
-      if (content !== lastSavedContent.current && documentId) {
+    debounce((currentContentValue: string) => {
+      // Get the LATEST value of isCreatingNewDocument from the store
+      const isCurrentlyCreating = useEditorStore.getState().isCreatingNewDocument;
+
+      if (isCurrentlyCreating) {
+        // Optional: log that save is skipped
+        // console.log("Auto-save skipped: isCreatingNewDocument is true.");
+        return;
+      }
+
+      // documentId is the prop passed to MonacoEditor
+      if (currentContentValue !== lastSavedContent.current && documentId) {
         setAutoSaveStatus("Saving...");
-        autoSaveMutation.mutate(content);
+        autoSaveMutation.mutate(currentContentValue);
       }
     }, 2000)
   ).current;

--- a/client/src/stores/editorStore.ts
+++ b/client/src/stores/editorStore.ts
@@ -7,11 +7,13 @@ interface EditorState {
   autoSaveStatus: "Saved" | "Saving..." | "Auto-saved" | "Save failed";
   wordCount: number;
   charCount: number;
+  isCreatingNewDocument: boolean; // Added flag
   
   // Actions
   setCurrentDocument: (document: DocumentWithDetails | null) => void;
   setContent: (content: string) => void;
   setAutoSaveStatus: (status: EditorState["autoSaveStatus"]) => void;
+  setIsCreatingNewDocument: (isCreating: boolean) => void; // Added action
   // updateWordCount and updateCharCount methods will be removed
 }
 
@@ -21,6 +23,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   autoSaveStatus: "Saved",
   wordCount: 0,
   charCount: 0,
+  isCreatingNewDocument: false, // Initialized flag
   
   setCurrentDocument: (document) => set({ currentDocument: document }),
   setContent: (content) => {
@@ -29,6 +32,7 @@ export const useEditorStore = create<EditorState>((set) => ({
     set({ content, wordCount: words, charCount: chars });
   },
   setAutoSaveStatus: (autoSaveStatus) => set({ autoSaveStatus }),
+  setIsCreatingNewDocument: (isCreating) => set({ isCreatingNewDocument: isCreating }), // Implemented action
   
   // updateWordCount and updateCharCount implementations are removed
   // updateWordCount: (content) => {


### PR DESCRIPTION
When importing content that creates a new document, a race condition could occur where the auto-save mechanism attempts to save the content before the new document is fully created and its ID is available. This could lead to the imported content not being saved correctly or attempts to save against an invalid document ID.

This commit introduces a new state flag `isCreatingNewDocument` in the `editorStore`.

- In `EditorLayout.tsx`, this flag is set to `true` before initiating the document creation mutation for an import and reset to `false` after the mutation completes (on success or error).
- In `MonacoEditor.tsx`, the `debouncedAutoSave` function now checks this flag. If `isCreatingNewDocument` is true, the auto-save operation is skipped. This ensures that auto-save does not interfere with the initial creation and saving of a new document from an imported source.

This change ensures that imported content is reliably saved when creating new documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved tracking of the document creation process during import, allowing the interface to recognize when a new document is being created.
- **Improvements**
  - Enhanced auto-save behavior to prevent saving while a new document is being created, ensuring a smoother user experience during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->