### PR TITLE
feat: Add 'Back to Editor' navigation from document view

### DIFF
--- a/client/src/components/EditorLayout.tsx
+++ b/client/src/components/EditorLayout.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext"; // Changed import
 import { useTheme } from "@/components/ThemeProvider";
-import { Info, Upload, Download as ExportIcon } from "lucide-react"; // Changed Download to ExportIcon
+import { Info, Upload, Download as ExportIcon, ArrowLeft } from "lucide-react"; // Changed Download to ExportIcon
 import AboutModal from "@/components/AboutModal";
-import { useLocation } from "wouter";
+import { Link, useLocation } from "wouter";
 import { useToast } from "@/hooks/use-toast"; // Import useToast
 import { Button } from "@/components/ui/button";
 import ImportDialog from "@/components/ImportDialog"; // Added import
@@ -24,10 +24,11 @@ import {
   Moon, 
   // Download, // Replaced by ExportIcon or Upload
   Share, // Share icon is currently used for Export button, will be replaced
-  Eye, 
-  Edit, 
-  Columns, 
-  Users
+  Eye,
+  Edit,
+  Columns,
+  Users,
+  // ArrowLeft // Already added to the other import
 } from "lucide-react";
 
 type ViewMode = "split" | "editor" | "preview";
@@ -200,6 +201,14 @@ export default function EditorLayout() {
           >
             <Menu className="w-5 h-5" />
           </Button>
+
+          {documentId && (
+            <Link href="/editor" aria-label="Back to editor">
+              <Button variant="ghost" size="icon" className="mr-2 text-foreground hover:bg-muted">
+                <ArrowLeft className="w-5 h-5" />
+              </Button>
+            </Link>
+          )}
           
           <div className="flex items-center space-x-3">
             <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">


### PR DESCRIPTION
This commit introduces a navigation link in the header of the document editing view, allowing you to easily return to the main '/editor' page.

Key changes:
- Added a left arrow icon link to `/editor` in `client/src/components/EditorLayout.tsx`.
- The link is conditionally rendered and only appears when viewing a specific document (i.e., when `documentId` is present in the URL).
- Styled using existing `Button` component with `variant="ghost"` for visual consistency with the application's minimalistic design.
- Includes an `aria-label="Back to editor"` for accessibility.
- I've checked it for responsiveness, visual consistency, and keyboard navigation.

This change improves your workflow by providing a clear and intuitive way to navigate back to the main editor interface from individual document pages.