### PR TITLE
Fix: Correct autosave logic in MonacoEditor

### DIFF
--- a/client/src/components/MonacoEditor.tsx
+++ b/client/src/components/MonacoEditor.tsx
@@ -33,13 +33,14 @@ export default function MonacoEditor({ documentId }: MonacoEditorProps) {
 
   // Auto-save mutation
   const autoSaveMutation = useMutation({
-    mutationFn: async (content: string) => {
+    mutationFn: async (newContent: string) => {
       if (!documentId) return;
-      await apiRequest("PATCH", `/api/documents/${documentId}`, { content });
+      await apiRequest("PATCH", `/api/documents/${documentId}`, { content: newContent });
+      return newContent;
     },
-    onSuccess: () => {
+    onSuccess: (returnedData, variables) => {
       setAutoSaveStatus("Auto-saved");
-      lastSavedContent.current = content;
+      lastSavedContent.current = variables;
     },
     onError: (error) => {
       if (isUnauthorizedError(error)) {
@@ -75,7 +76,7 @@ export default function MonacoEditor({ documentId }: MonacoEditorProps) {
       }
 
       // documentId is the prop passed to MonacoEditor
-      if (currentContentValue !== lastSavedContent.current && documentId) {
+      if (documentId && currentContentValue !== lastSavedContent.current) {
         setAutoSaveStatus("Saving...");
         autoSaveMutation.mutate(currentContentValue);
       }


### PR DESCRIPTION
The autosave mechanism was failing to persist changes reliably because the reference to the last saved content was not being updated correctly.

This commit addresses the issue by:
1.  Modifying the `autoSaveMutation` in `MonacoEditor.tsx`'s `onSuccess` handler to use the `variables` passed to the mutation (which is the actual content string that was attempted to save) to update `lastSavedContent.current`.
2.  Ensuring the `mutationFn` returns the content being saved so it's available if needed (though `variables` is used in `onSuccess`).
3.  Verifying that `debouncedAutoSave` only triggers a mutation if a valid `documentId` exists and the `currentContentValue` is different from `lastSavedContent.current`.

This ensures that autosave accurately tracks the last successfully persisted state and saves new changes correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved clarity in the auto-save functionality, including clearer parameter naming and callback handling.
  - Enhanced code readability by reordering conditions in the auto-save trigger logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->