### PR TITLE
Fix: Correct React Query URL for document loading

### DIFF
--- a/client/src/components/EditorLayout.tsx
+++ b/client/src/components/EditorLayout.tsx
@@ -128,7 +128,7 @@ export default function EditorLayout() {
 
   // Fetch current document
   const { data: document, isLoading } = useQuery({
-    queryKey: ["/api/documents", documentId],
+    queryKey: [`/api/documents/${documentId}`],
     enabled: !!documentId,
   });
 


### PR DESCRIPTION
The `queryKey` in `useQuery` for fetching a document was incorrectly constructed, leading to a malformed URL (e.g., `/api/documents?0=ID` instead of `/api/documents/ID`).

This change corrects the `queryKey` to use a template literal, ensuring that the correct API endpoint is called for fetching documents.

This resolves the critical bug where documents would save correctly but fail to load upon page refresh or direct navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the method for identifying document queries to improve consistency in data fetching. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->