### PR TITLE
Fix: Ensure documentId is initialized before use in EditorLayout

### DIFF
--- a/client/src/components/EditorLayout.tsx
+++ b/client/src/components/EditorLayout.tsx
@@ -40,6 +40,7 @@ export default function EditorLayout() {
   const { toast } = useToast(); // Initialize toast
   const queryClient = useQueryClient();
   const [sidebarOpen, setSidebarOpen] = useState(true);
+
   const [viewMode, setViewMode] = useState<ViewMode>("split");
   const [collaborationPanelOpen, setCollaborationPanelOpen] = useState(false);
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
@@ -64,6 +65,13 @@ export default function EditorLayout() {
   const documentId = location.startsWith("/document/") 
     ? parseInt(location.split("/")[2]) 
     : null;
+
+  // Force sidebar open on document pages
+  useEffect(() => {
+    if (documentId) {
+      setSidebarOpen(true);
+    }
+  }, [documentId]);
 
   // Mutation for creating new document
   const createDocumentMutation = useMutation({
@@ -200,14 +208,16 @@ export default function EditorLayout() {
       {/* Header */}
       <header className="bg-background border-b border-border px-4 py-3 flex items-center justify-between shadow-sm">
         <div className="flex items-center space-x-4">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="lg:hidden text-foreground hover:bg-muted"
-            onClick={() => setSidebarOpen(!sidebarOpen)}
-          >
-            <Menu className="w-5 h-5" />
-          </Button>
+          {!documentId && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="lg:hidden text-foreground hover:bg-muted"
+              onClick={() => setSidebarOpen(!sidebarOpen)}
+            >
+              <Menu className="w-5 h-5" />
+            </Button>
+          )}
 
           {documentId && (
             <Link href="/editor" aria-label="Back to editor">
@@ -338,7 +348,7 @@ export default function EditorLayout() {
         {/* Sidebar */}
         <DocumentSidebar 
           isOpen={sidebarOpen} 
-          onClose={() => setSidebarOpen(false)}
+          onClose={documentId ? () => {} : () => setSidebarOpen(false)}
         />
 
         {/* Main Editor Area */}


### PR DESCRIPTION
Resolved a ReferenceError that occurred because `documentId` was accessed by a `useEffect` hook before its declaration and initialization. The hook has been moved to execute after `documentId` is available.

Feat: Keep documents sidebar always open on document pages

This commit improves your experience in MarkdownMate by making the documents sidebar persistently open when you are viewing or editing a document.

Key changes in `client/src/components/EditorLayout.tsx`:
- Added a `useEffect` hook to force `sidebarOpen` to `true` when `documentId` is present.
- Conditionally hid the sidebar toggle menu button on document pages.
- Modified the `DocumentSidebar`'s `onClose` prop to prevent closing when on a document page.

These changes ensure quick navigation and better context awareness during document editing sessions, aligning with UX best practices seen in modern editors.