### PR TITLE
Fix: Correct Monaco Editor content synchronization for autosave

### DIFF
--- a/client/src/components/MonacoEditor.tsx
+++ b/client/src/components/MonacoEditor.tsx
@@ -17,7 +17,9 @@ export default function MonacoEditor({ documentId }: MonacoEditorProps) {
   const { theme } = useTheme();
   // const { toast } = useToast(); // toast is not used in the new fetch-based save logic directly
   const editorRef = useRef<any>(null);
-  const lastSavedContent = useRef<string>("");
+  const lastSavedContent = useRef<string | undefined>(undefined);
+  // Track if we've synced the loaded document content yet
+  const hasInitializedRef = useRef<number | null>(null); // Add this line
 
   const {
     content, 
@@ -28,19 +30,18 @@ export default function MonacoEditor({ documentId }: MonacoEditorProps) {
   } = useEditorStore();
 
   // Initialize lastSavedContent when document loads
-  useEffect(() => {
-    // console.log('[MonacoEditor Sync] useEffect for lastSavedContent triggered.');
-    // console.log('[MonacoEditor Sync] documentId:', documentId, 'Store content length:', content?.length);
+  // Track if we've synced the loaded document content yet
+  // const hasInitializedRef = useRef<number | null>(null); // This line is defined above
 
-    if (documentId && content !== undefined) {
-      // console.log('[MonacoEditor Sync] Before update - lastSavedContent.current (length):', lastSavedContent.current?.length);
+  useEffect(() => {
+    // Only sync lastSavedContent once when document first loads
+    if (documentId && content !== undefined && hasInitializedRef.current !== documentId) {
+      // This is a newly loaded document - sync it regardless of content
       lastSavedContent.current = content;
-      // console.log('[MonacoEditor Sync] After update - lastSavedContent.current (length):', lastSavedContent.current?.length);
+      hasInitializedRef.current = documentId;
+      console.log('[MonacoEditor Sync] Initial document sync - lastSavedContent set to length:', content.length);
     }
-    // else {
-    //   console.log('[MonacoEditor Sync] Conditions not met to update lastSavedContent.current. documentId:', documentId, 'content is undefined:', content === undefined);
-    // }
-  }, [documentId, content]); // 'content' is from useEditorStore()
+  }, [documentId, content]);
 
   // WebSocket for real-time collaboration
   const { sendMessage, isConnected } = useWebSocket(documentId);


### PR DESCRIPTION
The `lastSavedContent.current` in MonacoEditor was not being synchronized correctly with the document content loaded via React Query. This led to issues with the autosave feature, as it would compare against stale or incorrectly initialized content.

This commit addresses the issue by:
1. Introducing a `hasInitializedRef` (useRef hook) to track whether the content for a given `documentId` has been synced to `lastSavedContent.current` upon its initial load.
2. Modifying the `useEffect` hook (dependent on `documentId` and `content`) to update `lastSavedContent.current` only once when a document is first loaded (`hasInitializedRef.current !== documentId`).
3. This ensures that `lastSavedContent.current` is set accurately with the true initial content (including empty documents) from React Query before any of your edits or autosave comparisons occur.
4. It prevents `lastSavedContent.current` from being prematurely set to an empty string or being re-synced unnecessarily on subsequent content changes that are not the initial load.

This approach resolves the race condition and ensures that the autosave mechanism compares against the correctly loaded document content, making autosave reliable for all documents, including those that are legitimately empty.