### PR TITLE
Fix: Correct ContextMenu structure in DocumentSidebar

### DIFF
--- a/client/src/components/DocumentSidebar.tsx
+++ b/client/src/components/DocumentSidebar.tsx
@@ -433,23 +433,15 @@ export default function DocumentSidebar({ isOpen, onClose }: DocumentSidebarProp
                   </div>
                 ) : displayedDocuments.length > 0 ? (
                   displayedDocuments.map((document) => (
-                    <ContextMenuTrigger key={document.id}>
-                      <ContextMenuContent>
-                        <ContextMenuItem onSelect={() => handleRenameInitiate(document)}>
-                          Rename
-                        </ContextMenuItem>
-                        <ContextMenuItem onSelect={() => handleDeleteInitiate(document)}>
-                          Delete
-                        </ContextMenuItem>
-                      </ContextMenuContent>
-                      {/* Main clickable div for navigation and inline editing display */}
-                      <div
-                        className="flex items-center justify-between p-3 rounded-lg hover:bg-sidebar-accent group cursor-pointer transition-colors"
-                        onClick={() => handleDocumentClick(document)}
-                        // onContextMenu={(e) => e.preventDefault()} // Already handled by ContextMenuTrigger
-                      >
-                        <div className="flex items-center space-x-3 flex-1 min-w-0">
-                          <FileText className="h-4 w-4 text-muted-foreground" />
+                    <ContextMenu key={document.id}>
+                      <ContextMenuTrigger asChild>
+                        {/* Main clickable div for navigation and inline editing display */}
+                        <div
+                          className="flex items-center justify-between p-3 rounded-lg hover:bg-sidebar-accent group cursor-pointer transition-colors"
+                          onClick={() => handleDocumentClick(document)}
+                        >
+                          <div className="flex items-center space-x-3 flex-1 min-w-0">
+                            <FileText className="h-4 w-4 text-muted-foreground" />
                           <div className="flex-1 min-w-0">
                             {editingDocumentId === document.id ? (
                               <Input
@@ -502,7 +494,16 @@ export default function DocumentSidebar({ isOpen, onClose }: DocumentSidebarProp
                           </Button>
                         </div>
                       </div>
-                    </ContextMenuTrigger>
+                      </ContextMenuTrigger>
+                      <ContextMenuContent>
+                        <ContextMenuItem onSelect={() => handleRenameInitiate(document)}>
+                          Rename
+                        </ContextMenuItem>
+                        <ContextMenuItem onSelect={() => handleDeleteInitiate(document)}>
+                          Delete
+                        </ContextMenuItem>
+                      </ContextMenuContent>
+                    </ContextMenu>
                   ))
                 ) : (
                   <div className="text-sm text-muted-foreground">


### PR DESCRIPTION
The ContextMenuTrigger component was missing its required ContextMenu parent, causing an error. This commit wraps the ContextMenuTrigger and ContextMenuContent within a ContextMenu component in DocumentSidebar.tsx.

The `asChild` prop has been added to ContextMenuTrigger to correctly pass the trigger to its child div. The content structure within the trigger has been maintained.

This change ensures the proper functioning of the right-click context menu for document items (Rename, Delete) while preserving all existing functionalities like click navigation and inline action buttons.