### PR TITLE
Fix: Handle NaN in document ID and add title/error handling

### DIFF
--- a/client/src/components/EditorLayout.tsx
+++ b/client/src/components/EditorLayout.tsx
@@ -63,8 +63,35 @@ export default function EditorLayout() {
 
   // Extract document ID from URL
   const documentId = location.startsWith("/document/") 
-    ? parseInt(location.split("/")[2]) 
+  ? parseInt(location.split("/")[2], 10) || null
     : null;
+
+  // Set browser tab title based on current document
+  useEffect(() => {
+    if (currentDocument?.title) {
+      document.title = `${currentDocument.title} - MarkdownMate`;
+    } else if (documentId) {
+      document.title = "Loading... - MarkdownMate";
+    } else {
+      document.title = "MarkdownMate";
+    }
+  }, [currentDocument?.title, documentId]);
+
+  // Validate document ID and handle invalid URLs
+  useEffect(() => {
+    if (location.startsWith("/document/")) {
+      const idStr = location.split("/")[2];
+      if (!idStr || isNaN(parseInt(idStr, 10))) {
+        console.warn("Invalid document ID in URL:", idStr);
+        toast({
+          title: "Invalid Document ID",
+          description: "The document ID in the URL is invalid. Redirecting to editor.",
+          variant: "destructive",
+        });
+        setLocation("/editor");
+      }
+    }
+  }, [location, setLocation, toast]);
 
   // Force sidebar open on document pages
   useEffect(() => {


### PR DESCRIPTION
This commit addresses three issues in EditorLayout.tsx:

1.  Fixes a bug where `parseInt` could return `NaN` for the document ID if the URL was malformed, by ensuring it defaults to `null`.
2.  Adds dynamic browser tab title management. The title now reflects the current document's name, a loading state, or the default "MarkdownMate".
3.  Implements error handling for invalid document IDs in the URL. If an invalid ID is detected, a warning is logged, a toast notification is shown to you, and you are redirected to the main editor page.