### PR TITLE
HOTFIX: Prevent document.title access in non-browser environment

### DIFF
--- a/client/src/components/EditorLayout.tsx
+++ b/client/src/components/EditorLayout.tsx
@@ -66,8 +66,13 @@ export default function EditorLayout() {
   ? parseInt(location.split("/")[2], 10) || null
     : null;
 
-  // Set browser tab title based on current document
+  // Set browser tab title based on current document (with safety check)
   useEffect(() => {
+    // Only run in browser environment
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
     if (currentDocument?.title) {
       document.title = `${currentDocument.title} - MarkdownMate`;
     } else if (documentId) {


### PR DESCRIPTION
This commit fixes a critical error where `document.title` was being accessed before it was available (e.g., during SSR or due to React Strict Mode double execution).

The `useEffect` hook in `EditorLayout.tsx` responsible for setting the browser tab title has been updated to include a check for `typeof window === 'undefined' || typeof document === 'undefined'`. This ensures that `document.title` is only manipulated in a valid browser context, resolving the blank screen error.