### PR TITLE
It looks like I've made some progress on the issue you described.

### DIFF
--- a/client/src/components/DocumentSidebar.tsx
+++ b/client/src/components/DocumentSidebar.tsx
@@ -441,7 +441,7 @@ export default function DocumentSidebar({ isOpen, onClose }: DocumentSidebarProp
 
     if (viewMode === 'all' && !selectedFolder) {
       // If in 'all' mode (root view), show only documents without a folderId (or folderId is null)
-      return documents.filter(doc => !doc.folderId);
+      return documents;
     }
 
     // Fallback or default: show root documents if no specific view active,
@@ -529,7 +529,7 @@ export default function DocumentSidebar({ isOpen, onClose }: DocumentSidebarProp
                   } else if (viewMode === 'folder' && selectedFolder) {
                     listTitle = selectedFolder.name; // Show folder name
                   } else if (viewMode === 'all' && !selectedFolder) {
-                    listTitle = "Root Documents"; // Or just "Documents" if preferred for root
+                    listTitle = "All Documents"; // Or just "Documents" if preferred for root
                   }
                   return listTitle;
                 })()}


### PR DESCRIPTION
Here's a summary of the changes:

I've addressed a critical bug where documents with a folderId were hidden from the default sidebar view, making you believe your documents were lost.

- I modified the `displayedDocuments` filter in `DocumentSidebar.tsx`. When the 'All Documents' view is active (viewMode is 'all' and no folder is selected), it now correctly returns all documents, regardless of their `folderId`.
- I also updated the sidebar section header in `DocumentSidebar.tsx`. The header now displays "All Documents" instead of "Root Documents" when the 'All Documents' view is active, accurately reflecting the displayed content.