### PR TITLE
Fix: Allow scrolling beyond the last line in the editor

### DIFF
--- a/client/src/components/MonacoEditor.tsx
+++ b/client/src/components/MonacoEditor.tsx
@@ -194,7 +194,7 @@ export default function MonacoEditor({ documentId }: MonacoEditorProps) {
           fontSize: 14,
           fontFamily: "JetBrains Mono, Menlo, Monaco, monospace",
           padding: { top: 16, bottom: 16 },
-          scrollBeyondLastLine: false,
+          scrollBeyondLastLine: true,
           automaticLayout: true,
           cursorBlinking: "smooth",
           cursorSmoothCaretAnimation: "on",


### PR DESCRIPTION
This change addresses an issue where you could not scroll to the very end of your documents, making it difficult to view or edit content at the bottom.

The `scrollBeyondLastLine` option in the Monaco Editor configuration was changed from `false` to `true`. This modification allows you to scroll past the final line of text, providing additional space at the end of the editor and improving usability for long documents.

When you review this, you should verify that:
- You can scroll past the last line of content in a long document.
- Empty space is visible below the last line after scrolling down fully.
- Editing and adding new content at the very end of the document is now comfortable.
- No other editor functionalities are negatively impacted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the editor to allow scrolling beyond the last line, providing a smoother scrolling experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->