### PR TITLE
Fix: Enable independent scrolling for Markdown preview pane

### DIFF
--- a/client/src/components/EditorLayout.tsx
+++ b/client/src/components/EditorLayout.tsx
@@ -434,7 +434,7 @@ export default function EditorLayout() {
 
             {/* Preview Panel */}
             {(viewMode === "split" || viewMode === "preview") && (
-              <div className="flex-1 flex flex-col">
+              <div className="flex-1 flex flex-col overflow-y-auto">
                 <div className="bg-muted px-4 py-2 border-b border-border">
                   <h3 className="text-sm font-medium text-foreground">Preview</h3>
                 </div>


### PR DESCRIPTION
The preview pane was not scrolling independently, preventing you from viewing the entire rendered document. This was particularly problematic for long documents.

This commit fixes the issue by adding the `overflow-y-auto` Tailwind CSS class to the `div` container that wraps the `MarkdownPreview` component in `EditorLayout.tsx`. This ensures that the container will allow vertical scrolling if its content overflows, enabling you to scroll through the entire preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the preview panel in the editor layout by enabling vertical scrolling when content exceeds the visible area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->